### PR TITLE
Make `MessageConverter::getMsgType()` constexpr

### DIFF
--- a/nanopb_cpp.h
+++ b/nanopb_cpp.h
@@ -394,7 +394,7 @@ namespace NanoPb {
             using DecoderContext = LocalType&;
 
         public:
-            static const pb_msgdesc_t *getMsgType(){ return PROTO_TYPE_MSG; }
+            static constexpr const pb_msgdesc_t *getMsgType(){ return PROTO_TYPE_MSG; }
 
         public:
             static bool encodeCallback(pb_ostream_t *stream, const pb_field_t *field, const LocalType &local){


### PR DESCRIPTION
Allows calling this method in template parameters